### PR TITLE
1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ modules: {
 }
 ```
 
+```javascript
+// Anywhere you have a rich text widget that should support
+// AI-generated rich text
+someAreaName: {
+  widgets: {
+    '@apostrophecms/rich-text': {
+      toolbar: [
+        'styles',
+        'bold'
+      ],
+      insert: [
+        'ai'
+      ],
+      // Generated text includes headings if asked for
+      styles: [
+        {
+          name: 'Heading',
+          element: 'h2'
+        },
+        {
+          name: 'Subheading',
+          element: 'h3'
+        },
+        {
+          name: 'Paragraph',
+          element: 'p'
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Run
 
 ```bash
@@ -29,21 +62,37 @@ node app
 
 ## Usage
 
+### Image Generation
+
 Add an image widget to the page. Click the edit pencil, then "Browse" as you normally would.
 
-When the media manager appears, click the "robot" button in the upper right corner:
-
-![Editing Roles by Group](images/screenshot-1.png)
+When the media manager appears, click the "🤖" (robot) button in the upper right corner.
 
 When the "Generate Image" dialog appears, follow the instructions to enter a plain English
-description of the image you want. Then click "Generate." You can do this as many times as
-you wish.
+description of the image you want. Then click "Generate." After a pause, four images
+will appear. You can do this as many times as you wish.
 
-When you are happy with the results, click on the best of the four images to insert it
-into the media library and select it. Then save your selection as you normally would.
-
-## Notes
+When you are happy with the results, click on the best of the four images to review it
+and click "Select" to bring it into the media library, "Variants" to generate
+variants of it, or "Delete" to discard it.
 
 The image helper generates 1024x1024 images. This is the maximum size supported by OpenAI.
 As of this writing, smaller images are not much cheaper, and are unlikely to look good
 in various placements on a website.
+
+Note that generated images not selected for use in the media library after one hour will
+be discarded by OpenAI. Those you select are permanently imported to the media library.
+
+### Text Generation
+
+Configure a rich text widget with the `insert` subproperty configured as shown above.
+
+Now press the "/" (slash) key at the start of any line to bring up the insert menu.
+Choose "Generate Text" to generate text.
+
+Enter a prompt as suggested and click "Generate." After a pause, the generated text
+is inserted into the rich text widget.
+
+Note that the generated text can include headings and links if you so request.
+It is also a good idea to specify a word count. You can make your request using
+ordinary conversational language.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ someAreaName: {
 }
 ```
 
+
+```javascript
+// in modules/@apostrophecms/security-headers/index.js,
+// only if you are using that module in your project
+module.exports = {
+  options: {
+    policies: {
+      ai: {
+        // Images served by OpenAI, for editing purposes only
+        'img-src': '*.blob.core.windows.net'
+      }
+    }
+  }
+};
+```
+
 ## Run
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ you wish.
 
 When you are happy with the results, click on the best of the four images to insert it
 into the media library and select it. Then save your selection as you normally would.
+
+## Notes
+
+The image helper generates 1024x1024 images. This is the maximum size supported by OpenAI.
+As of this writing, smaller images are not much cheaper, and are unlikely to look good
+in various placements on a website.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ module.exports = {
 ## Run
 
 ```bash
-export OPENAI_KEY=get-your-own-key-from-openai
+export APOS_OPENAI_KEY=get-your-own-key-from-openai
 node app
 ```
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = {
+  init() {
+    if (!(process.env.APOS_OPENAI_KEY || process.env.APOS_AI_HELPER_MOCK)) {
+      // We do not document the mock because it is for internal testing
+      throw new Error('APOS_OPENAI_KEY must be set in your environment');
+    }
+  },
   bundle: {
     directory: 'modules',
     modules: getBundleModuleNames()

--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = {
   bundle: {
     directory: 'modules',
     modules: getBundleModuleNames()
+  },
+  options: {
+    textModel: 'text-davinci-003',
+    textMaxTokens: 1000
   }
 };
 

--- a/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
+++ b/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
@@ -1,4 +1,7 @@
 {
   "generateImage": "Generate Image",
-  "placeholderText": "Describe the image you want to create."
+  "placeholderText": "Describe the image you want to create.",
+  "variations": "Variations",
+  "select": "Select",
+  "delete": "Delete"
 }

--- a/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
+++ b/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
@@ -7,5 +7,7 @@
   "variations": "Variations",
   "select": "Select",
   "delete": "Delete",
-  "generateTextAction": "Generate"
+  "generateTextAction": "Generate",
+  "rateLimitExceeded": "Rate limit exceeded, try again later",
+  "invalidRequest": "Invalid request, please review OpenAI's rules"
 }

--- a/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
+++ b/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
@@ -3,7 +3,7 @@
   "generateTextLabel": "Generate Text",
   "generateTextDescription": "Generate text with AI",
   "imagePlaceholderText": "Describe the image you want to create.",
-  "textPlaceholderText": "Describe the text you want to write.",
+  "textPromptLabel": "Enter a prompt to generate text. Example: \"100 words about cheese, in the style of Anthony Bourdain, with subheadings\"",
   "variations": "Variations",
   "select": "Select",
   "delete": "Delete",

--- a/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
+++ b/modules/@apostrophecms/ai-helper-image/i18n/aposAiHelper/en.json
@@ -1,7 +1,11 @@
 {
   "generateImage": "Generate Image",
-  "placeholderText": "Describe the image you want to create.",
+  "generateTextLabel": "Generate Text",
+  "generateTextDescription": "Generate text with AI",
+  "imagePlaceholderText": "Describe the image you want to create.",
+  "textPlaceholderText": "Describe the text you want to write.",
   "variations": "Variations",
   "select": "Select",
-  "delete": "Delete"
+  "delete": "Delete",
+  "generateTextAction": "Generate"
 }

--- a/modules/@apostrophecms/ai-helper-image/index.js
+++ b/modules/@apostrophecms/ai-helper-image/index.js
@@ -148,6 +148,13 @@ module.exports = {
             return {
               images
             };
+          } catch (e) {
+            if (e.status === 429) {
+              self.apos.notify(req, 'aposAiHelper:rateLimitExceeded');
+            } else if (e.status === 400) {
+              self.apos.notify(req, 'aposAiHelper:invalidRequest');
+            }
+            throw e;
           } finally {
             if (temp) {
               try {

--- a/modules/@apostrophecms/ai-helper-image/index.js
+++ b/modules/@apostrophecms/ai-helper-image/index.js
@@ -26,7 +26,7 @@ module.exports = {
         relationships: true,
         button: true,
         modalOptions: {
-          modal: 'AposAiHelperGenerateImage'
+          modal: 'AposAiHelperImageManager'
         }
       }
     }
@@ -90,6 +90,22 @@ module.exports = {
           set('n', 4);
           set('size', '1024x1024');
           let temp;
+          // Fake results for cheap & offline testing
+          if (process.env.APOS_AI_HELPER_MOCK) {
+            const now = new Date();
+            const images = [];
+            for (let i = 0; (i < 4); i++) {
+              images.push({
+                _id: cuid(),
+                userId: req.user._id,
+                createdAt: now,
+                url: self.apos.asset.url('/modules/@apostrophecms/ai-helper-image/placeholder.jpg')
+              });
+            }
+            return {
+              images
+            };
+          }
           try {
             if (variantOf) {
               const existing = await self.aiHelperImages.findOne({

--- a/modules/@apostrophecms/ai-helper-image/index.js
+++ b/modules/@apostrophecms/ai-helper-image/index.js
@@ -120,7 +120,7 @@ module.exports = {
             const command = variantOf ? 'variations' : 'generations';
             const result = await self.apos.http.post(`https://api.openai.com/v1/images/${command}`, {
               headers: {
-                Authorization: `Bearer ${process.env.OPENAI_KEY}`
+                Authorization: `Bearer ${process.env.APOS_OPENAI_KEY}`
               },
               body
             });

--- a/modules/@apostrophecms/ai-helper-image/index.js
+++ b/modules/@apostrophecms/ai-helper-image/index.js
@@ -84,7 +84,9 @@ module.exports = {
             throw self.apos.error('invalid');
           }
           const body = variantOf ? new FormData() : {};
-          set('prompt', prompt);
+          if (!variantOf) {
+            set('prompt', prompt);
+          }
           set('n', 4);
           set('size', '1024x1024');
           let temp;
@@ -97,9 +99,10 @@ module.exports = {
                 throw self.apos.error('notfound');
               }
               temp = await self.aiHelperFetchImage(existing._id, existing.url);
-              body('image', fs.createReadStream(temp));
+              body.append('image', fs.createReadStream(temp));
             }
-            const result = await self.apos.http.post('https://api.openai.com/v1/images/generations', {
+            const command = variantOf ? 'variations' : 'generations';
+            const result = await self.apos.http.post(`https://api.openai.com/v1/images/${command}`, {
               headers: {
                 Authorization: `Bearer ${process.env.OPENAI_KEY}`
               },

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperGenerateImage.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperGenerateImage.vue
@@ -36,7 +36,7 @@
                   :label="$t('aposAiHelper:select')"
                 />
                 <AposButton
-                  @click.prevent="generate(image)"
+                  @click.prevent="generate({ variantOf: image })"
                   icon="group-icon"
                   :icon-only="true"
                   :label="$t('aposAiHelper:variations')"
@@ -86,12 +86,13 @@ export default {
       try {
         const result = await self.apos.http.post(`${apos.image.action}/ai-helper`, {
           body: {
-            prompt: variantOf ? variantOf.prompt : this.prompt,
-            variantOf: variantOf._id
+            prompt: variantOf?.prompt || this.prompt,
+            variantOf: variantOf?._id
           },
           busy: true
         });
-        this.images = [ ...result.images, this.images ];
+        this.images = [ ...result.images, ...this.images ];
+        console.log(JSON.stringify(this.images, null, '  '));
         this.$el.scrollTo(0, 0);
       } catch (e) {
         console.error(e);

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageEditor.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageEditor.vue
@@ -8,6 +8,12 @@
     @esc="close"
     @no-modal="$emit('safe-close')"
   >
+    <template #primaryControls>
+      <AposButton
+        type="default" label="apostrophe:close"
+        @click="close"
+      />
+    </template>
     <template #main>
       <AposModalBody>
         <template #bodyMain>
@@ -22,6 +28,7 @@
                 @click.prevent="action('save')"
                 icon="plus-icon"
                 :label="$t('aposAiHelper:select')"
+                type="primary"
               />
               <AposButton
                 @click.prevent="action('variations')"
@@ -30,8 +37,9 @@
               />
               <AposButton
                 @click.prevent="action('delete')"
+                icon="delete-icon"
                 :label="$t('aposAiHelper:delete')"
-                :icon-only="true"
+                type="danger"
               />
             </div>
             <p v-if="error">
@@ -63,15 +71,24 @@ export default {
       error: false
     };
   },
-  async mounted() {
+  mounted() {
     this.modal.active = true;
+    const expireMs = new Date(this.image.createdAt).getTime() + 1000 * 60 * 60;
+    const nowMs = Date.getTime();
+    const timeout = expireMs - nowMs;
+    this.expireTimeout = setTimeout(this.expire, Math.max(timeout, 0));
+  },
+  destroyed() {
+    clearTimeout(this.expireTimeout);
   },
   methods: {
+    expire() {
+      this.modal.showModal = false;
+    },
     close() {
       this.modal.showModal = false;
     },
     action(action) {
-      console.log('action is:', action);
       this.modal.showModal = false;
       this.$emit('modal-result', {
         action
@@ -82,6 +99,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// Prevent scrollbar and ensure image shrinks to box rather than growing
+// in proportion to 100% width
 ::v-deep .apos-modal__main, ::v-deep .apos-modal__body-inner, ::v-deep .apos-modal__body-main {
   height: 100%;
   min-height: 0;
@@ -90,14 +109,16 @@ form {
   display: flex;
   flex-direction: column;
   height: 100%;
+  gap: 32px;
 }
 .apos-ai-helper-image {
   object-fit: contain;
   min-height: 0;
 }
-.apos-ai-helper-buttons {
+.apos-ai-helper-image-buttons {
   display: flex;
   flex-direction: row;
-  gap: 16px;
+  justify-content: center;
+  gap: 32px;
 }
 </style>

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageEditor.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageEditor.vue
@@ -17,7 +17,7 @@
     <template #main>
       <AposModalBody>
         <template #bodyMain>
-          <form>
+          <div class="apos-ai-helper-form">
             <img
               class="apos-ai-helper-image"
               :src="image.url"
@@ -45,7 +45,7 @@
             <p v-if="error">
               An error occurred.
             </p>
-          </form>
+          </div>
         </template>
       </AposModalBody>
     </template>
@@ -74,7 +74,7 @@ export default {
   mounted() {
     this.modal.active = true;
     const expireMs = new Date(this.image.createdAt).getTime() + 1000 * 60 * 60;
-    const nowMs = Date.getTime();
+    const nowMs = Date.now();
     const timeout = expireMs - nowMs;
     this.expireTimeout = setTimeout(this.expire, Math.max(timeout, 0));
   },
@@ -105,7 +105,7 @@ export default {
   height: 100%;
   min-height: 0;
 }
-form {
+.apos-ai-helper-form {
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageEditor.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageEditor.vue
@@ -1,0 +1,103 @@
+<template>
+  <AposModal
+    class="apos-ai-helper-image-editor"
+    :modal="modal"
+    modal-title="aposAiHelper:generateImage"
+    @inactive="modal.active = false"
+    @show-modal="modal.showModal = true"
+    @esc="close"
+    @no-modal="$emit('safe-close')"
+  >
+    <template #main>
+      <AposModalBody>
+        <template #bodyMain>
+          <form>
+            <img
+              class="apos-ai-helper-image"
+              :src="image.url"
+            >
+            <div class="apos-ai-helper-image-buttons">
+              <AposButton
+                :disabled="image.accepted"
+                @click.prevent="action('save')"
+                icon="plus-icon"
+                :label="$t('aposAiHelper:select')"
+              />
+              <AposButton
+                @click.prevent="action('variations')"
+                icon="group-icon"
+                :label="$t('aposAiHelper:variations')"
+              />
+              <AposButton
+                @click.prevent="action('delete')"
+                :label="$t('aposAiHelper:delete')"
+                :icon-only="true"
+              />
+            </div>
+            <p v-if="error">
+              An error occurred.
+            </p>
+          </form>
+        </template>
+      </AposModalBody>
+    </template>
+  </AposModal>
+</template>
+
+<script>
+export default {
+  props: {
+    image: {
+      type: Object,
+      required: true
+    }
+  },
+  emits: [ 'modal-result', 'safe-close' ],
+  data() {
+    return {
+      modal: {
+        active: false,
+        type: 'overlay',
+        showModal: true
+      },
+      error: false
+    };
+  },
+  async mounted() {
+    this.modal.active = true;
+  },
+  methods: {
+    close() {
+      this.modal.showModal = false;
+    },
+    action(action) {
+      console.log('action is:', action);
+      this.modal.showModal = false;
+      this.$emit('modal-result', {
+        action
+      });
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+::v-deep .apos-modal__main, ::v-deep .apos-modal__body-inner, ::v-deep .apos-modal__body-main {
+  height: 100%;
+  min-height: 0;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.apos-ai-helper-image {
+  object-fit: contain;
+  min-height: 0;
+}
+.apos-ai-helper-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+}
+</style>

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
@@ -60,8 +60,18 @@ export default {
   async mounted() {
     this.modal.active = true;
     this.images = (await self.apos.http.get(`${apos.image.action}/ai-helper`, { busy: true })).images;
+    this.expireInterval = setInterval(this.expire, 1000 * 60);
+  },
+  destroyed() {
+    clearInterval(this.expireInterval);
   },
   methods: {
+    expire() {
+      const expired = new Date(Date.now() - 1000 * 60 * 60).toISOString();
+      if (this.images.some(image => image.createdAt <= expired)) {
+        this.images = this.images.filter(image => image.createdAt > expired);
+      }
+    },
     close() {
       this.modal.showModal = false;
     },
@@ -79,7 +89,7 @@ export default {
         } else if (action === 'variations') {
           await this.generate({
             variantOf: image
-        });
+          });
         } else if (action === 'delete') {
           await this.remove(image);
         } else {

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
@@ -79,7 +79,7 @@ export default {
       const result = await apos.modal.execute('AposAiHelperImageEditor', {
         image
       });
-      const action = result.action;
+      const action = result?.action;
       // If I do this as !action: return I get a linter error 🤷‍♂️
       if (action) {
         if (action === 'save') {

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
@@ -79,9 +79,7 @@ export default {
       const result = await apos.modal.execute('AposAiHelperImageEditor', {
         image
       });
-      console.log('result is:', JSON.stringify(result));
       const action = result.action;
-      console.log('action in manager is:', action);
       // If I do this as !action: return I get a linter error 🤷‍♂️
       if (action) {
         if (action === 'save') {
@@ -108,7 +106,6 @@ export default {
           busy: true
         });
         this.images = [ ...result.images, ...this.images ];
-        console.log(JSON.stringify(this.images, null, '  '));
         this.$el.querySelector('[data-apos-modal-inner]').scrollTo(0, 0);
       } catch (e) {
         console.error(e);
@@ -117,7 +114,6 @@ export default {
     },
     async save({ _id }) {
       try {
-        console.log(`id is ${_id}`);
         const updated = await self.apos.http.patch(`${apos.image.action}/ai-helper/${_id}`, {
           body: {
             accepted: 1
@@ -125,7 +121,6 @@ export default {
           busy: true
         });
         const image = updated._image;
-        console.log('posting the content changed event after successful accept');
         this.$emit('modal-result', image);
         this.modal.showModal = false;
         apos.bus.$emit('content-changed', {

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
@@ -12,7 +12,7 @@
       <AposModalBody>
         <template #bodyMain>
           <form class="apos-ai-helper-form">
-            <textarea v-model="prompt" :placeholder="$t('aposAiHelper:placeholderText')" />
+            <textarea v-model="prompt" :placeholder="$t('aposAiHelper:imagePlaceholderText')" />
             <AposButton
               :disabled="!prompt.length"
               @click.prevent="generate({})"

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
@@ -1,3 +1,5 @@
+const marked = require('marked');
+
 module.exports = {
   improve: '@apostrophecms/rich-text-widget',
   beforeSuperClass(self) {
@@ -19,22 +21,32 @@ module.exports = {
       post: {
         async aiHelper(req) {
           const aiHelper = self.apos.modules['@apostrophecms/ai-helper'];
-          const prompt = self.apos.launder.string(req.body.prompt);
+          let prompt = self.apos.launder.string(req.body.prompt);
+          const headingLevels = self.apos.launder.strings(req.body.headingLevels);
           if (!prompt.length) {
             throw self.apos.error('invalid');
           }
-          const body = {
-            prompt,
-            model: aiHelper.options.textModel,
-            max_tokens: aiHelper.options.textMaxTokens,
-            n: 1
-          };
           // Fake results for cheap & offline testing
           if (process.env.APOS_AI_HELPER_MOCK) {
             return {
               text: 'The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog.'
             };
           }
+          prompt = `
+            Generate text in markdown format, using only the following heading levels:
+            
+            ${headingLevels.join(', ')}
+            
+            Based on the following prompt:
+            
+            ${prompt}
+          `;
+          const body = {
+            prompt,
+            model: aiHelper.options.textModel,
+            max_tokens: aiHelper.options.textMaxTokens,
+            n: 1
+          };
           try {
             const result = await self.apos.http.post(`https://api.openai.com/v1/completions`, {
               headers: {
@@ -46,8 +58,10 @@ module.exports = {
               throw self.apos.error('error');
             }
             console.log(JSON.stringify(result, null, '  '));
+            const html = marked.parse(result.choices[0].text);
+            console.log(html);
             return {
-              text: result.choices[0].text
+              html
             };
           } catch (e) {
             console.error(JSON.stringify(e, null, '  '));

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
@@ -58,7 +58,7 @@ module.exports = {
           const result = process.env.APOS_AI_HELPER_MOCK ? mockResults :
             await self.apos.http.post(`https://api.openai.com/v1/completions`, {
               headers: {
-                Authorization: `Bearer ${process.env.OPENAI_KEY}`
+                Authorization: `Bearer ${process.env.APOS_OPENAI_KEY}`
               },
               body
             })

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
@@ -1,0 +1,60 @@
+module.exports = {
+  improve: '@apostrophecms/rich-text-widget',
+  beforeSuperClass(self) {
+    self.options.editorInsertMenu = {
+      ...self.options.editorInsertMenu,
+      ai: {
+        icon: 'robot-icon',
+        label: 'aposAiHelper:generateTextLabel',
+        component: 'AposAiHelperTextDialog',
+        description: 'aposAiHelper:generateTextDescription'
+      }
+    };
+  },
+  init(self) {
+    console.log(Object.keys(self.options.editorInsertMenu));
+  },
+  apiRoutes(self) {
+    return {
+      post: {
+        async aiHelper(req) {
+          const aiHelper = self.apos.modules['@apostrophecms/ai-helper'];
+          const prompt = self.apos.launder.string(req.body.prompt);
+          if (!prompt.length) {
+            throw self.apos.error('invalid');
+          }
+          const body = {
+            prompt,
+            model: aiHelper.options.textModel,
+            max_tokens: aiHelper.options.textMaxTokens,
+            n: 1
+          };
+          // Fake results for cheap & offline testing
+          if (process.env.APOS_AI_HELPER_MOCK) {
+            return {
+              text: 'The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog.'
+            };
+          }
+          try {
+            const result = await self.apos.http.post(`https://api.openai.com/v1/completions`, {
+              headers: {
+                Authorization: `Bearer ${process.env.OPENAI_KEY}`
+              },
+              body
+            });
+            if (!result?.choices?.[0]?.text) {
+              throw self.apos.error('error');
+            }
+            console.log(JSON.stringify(result, null, '  '));
+            return {
+              text: result.choices[0].text
+            };
+          } catch (e) {
+            console.error(JSON.stringify(e, null, '  '));
+            throw e;
+          }
+        }
+      }
+    };
+  }  
+}

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
@@ -1,5 +1,26 @@
 const marked = require('marked');
 
+// Canned sample results for cheap & offline testing
+const mockResults = {
+  "id": "cmpl-76iWL6JGwp0S3MoFx77100hd4cZjr",
+  "object": "text_completion",
+  "created": 1681835461,
+  "model": "text-davinci-003",
+  "choices": [
+    {
+      "text": "\n# Glamping Cats\n\n## The Feline Appeal\nGlamping cats have become increasingly popular in recent years, with many people choosing to include their cats in their glamping experience. Cats are incredibly adaptive and can quickly become accustomed to new environments with minimal stress. They can also make perfect glamping companions, as their intelligence and inquisitive nature ensure that they will quickly find ways to entertain themselves and those around them.\n\n## Glamping Must-Haves\nBefore taking your cat on a glamping vacation, make sure you are prepared. Consider bringing items such as litterbox, food dish, bedding material, and toys. Each of these items can help create an enjoyable and stress-free environment for your cat while glamping.\n\n## RV Luxuries\nRVs come equipped with a variety of amenities that make glamping with cats more enjoyable. Consider portable kennels and carriers for your cat, as well as waterproof mats and blankets for lounging. RV heating capabilities can also create a comfortable and safe environment for your cat, no matter the temperature outside. \n\n## All-Weather Fun\nGlamping with cats can provide opportunities for outdoor fun regardless of the weather. Rainy days can be spent cuddling cats inside, while sunny days can offer the adventure of roaming the outdoors. Glamping can also offer cats the opportunity to meet new people and explore new environments.\n\n## A Special Bond\nUltimately, glamping with cats can create a special bond between you and your pet. Cats tend to be incredibly social creatures and thrive off of human interaction. Glamping with cats offers the perfect opportunity to strengthen your relationship and appreciate the wonders of nature.",
+      "index": 0,
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 32,
+    "completion_tokens": 342,
+    "total_tokens": 374
+  }
+};
+
 module.exports = {
   improve: '@apostrophecms/rich-text-widget',
   beforeSuperClass(self) {
@@ -13,31 +34,18 @@ module.exports = {
       }
     };
   },
-  init(self) {
-    console.log(Object.keys(self.options.editorInsertMenu));
-  },
   apiRoutes(self) {
     return {
       post: {
         async aiHelper(req) {
           const aiHelper = self.apos.modules['@apostrophecms/ai-helper'];
           let prompt = self.apos.launder.string(req.body.prompt);
-          const headingLevels = self.apos.launder.strings(req.body.headingLevels);
+          const headingLevels = self.apos.launder.strings(req.body.headingLevels).map(level => parseInt(level));
           if (!prompt.length) {
             throw self.apos.error('invalid');
           }
-          // Fake results for cheap & offline testing
-          if (process.env.APOS_AI_HELPER_MOCK) {
-            return {
-              text: 'The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog. The quick brown fox generated the lazy dog.'
-            };
-          }
           prompt = `
-            Generate text in markdown format, using only the following heading levels:
-            
-            ${headingLevels.join(', ')}
-            
-            Based on the following prompt:
+            Generate text in markdown format, based on the following prompt:
             
             ${prompt}
           `;
@@ -47,26 +55,32 @@ module.exports = {
             max_tokens: aiHelper.options.textMaxTokens,
             n: 1
           };
-          try {
-            const result = await self.apos.http.post(`https://api.openai.com/v1/completions`, {
+          const result = process.env.APOS_AI_HELPER_MOCK ? mockResults :
+            await self.apos.http.post(`https://api.openai.com/v1/completions`, {
               headers: {
                 Authorization: `Bearer ${process.env.OPENAI_KEY}`
               },
               body
-            });
-            if (!result?.choices?.[0]?.text) {
-              throw self.apos.error('error');
-            }
-            console.log(JSON.stringify(result, null, '  '));
-            const html = marked.parse(result.choices[0].text);
-            console.log(html);
-            return {
-              html
-            };
-          } catch (e) {
-            console.error(JSON.stringify(e, null, '  '));
-            throw e;
+            })
+          ;
+          if (!result?.choices?.[0]?.text) {
+            throw self.apos.error('error');
           }
+          let markdown = result.choices[0].text;
+
+          // Remap headings to levels actually available in this widget
+          markdown = markdown.replace(/(^|\n)(#+) /g, (all, before, hashes) => {
+            if (!headingLevels.length) {
+              return '';
+            }
+            const level = headingLevels[hashes.length - 1];
+            return before + (level ? (before + '#'.repeat(level) + ' ') : '');
+          });
+
+          const html = marked.parse(markdown);
+          return {
+            html
+          };
         }
       }
     };

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/index.js
@@ -55,13 +55,15 @@ module.exports = {
             max_tokens: aiHelper.options.textMaxTokens,
             n: 1
           };
-          const result = process.env.APOS_AI_HELPER_MOCK ? mockResults :
-            await self.apos.http.post(`https://api.openai.com/v1/completions`, {
-              headers: {
-                Authorization: `Bearer ${process.env.APOS_OPENAI_KEY}`
-              },
-              body
-            })
+          const result = process.env.APOS_AI_HELPER_MOCK
+            ? mockResults
+            :
+              await self.apos.http.post(`https://api.openai.com/v1/completions`, {
+                headers: {
+                  Authorization: `Bearer ${process.env.APOS_OPENAI_KEY}`
+                },
+                body
+              })
           ;
           if (!result?.choices?.[0]?.text) {
             throw self.apos.error('error');

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
@@ -12,7 +12,7 @@
     <AposContextMenuDialog
       menu-placement="bottom-start"
     >
-      <form class="apos-ai-helper-form">
+      <div class="apos-ai-helper-form">
         <p>
           {{ $t('aposAiHelper:textPromptLabel') }}
         </p>
@@ -20,7 +20,7 @@
         <p v-if="error">
           An error occurred.
         </p>
-      </form>
+      </div>
       <footer class="apos-ai-helper-text__footer">
         <AposButton
           type="default" label="apostrophe:cancel"

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
@@ -1,0 +1,145 @@
+<template>
+  <div
+    v-if="active"
+    v-click-outside-element="close"
+    class="apos-popover apos-ai-helper-text__dialog"
+    x-placement="bottom"
+    :class="{
+      'apos-is-triggered': active,
+      'apos-has-selection': true
+    }"
+  >
+    <AposContextMenuDialog
+      menu-placement="bottom-start"
+    >
+      <form class="apos-ai-helper-form">
+        <textarea v-model="prompt" :placeholder="$t('aposAiHelper:textPlaceholderText')" />
+        <p v-if="error">
+          An error occurred.
+        </p>
+      </form>
+      <footer class="apos-ai-helper-text__footer">
+        <AposButton
+          type="default" label="apostrophe:cancel"
+          @click="close"
+          :modifiers="formModifiers"
+        />
+        <AposButton
+          type="primary" label="aposAiHelper:generateTextAction"
+          @click="save"
+          :disabled="!prompt.length"
+          :modifiers="formModifiers"
+        />
+      </footer>
+    </AposContextMenuDialog>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AposAiHelperTextDialog',
+  emits: [ 'close', 'beforeCommands' ],
+  props: {
+    editor: {
+      type: Object,
+      required: true
+    },
+    active: {
+      type: Boolean,
+      required: true
+    }
+  },
+  data() {
+    return {
+      prompt: '',
+      error: false,
+      formModifiers: [ 'small', 'margin-micro' ]
+    };
+  },
+  watch: {
+    active(newVal) {
+      if (newVal) {
+        window.addEventListener('keydown', this.keyboardHandler);
+      } else {
+        window.removeEventListener('keydown', this.keyboardHandler);
+      }
+    }
+  },
+  methods: {
+    close() {
+      console.log('emitting close');
+      this.$emit('close');
+    },
+    async save() {
+      this.error = false;
+      try {
+        const result = await self.apos.http.post(`${getOptions().action}/ai-helper`, {
+          body: {
+            prompt: this.prompt
+          },
+          busy: true
+        });
+        console.log(JSON.stringify(result, null, '  '));
+        this.$emit('beforeCommands');
+        this.editor.commands.insertContent(result.text);
+        this.close();
+      } catch (e) {
+        console.error(e);
+        this.error = true;
+      }
+    },
+    keyboardHandler(e) {
+      if (e.keyCode === 27) {
+        this.close();
+      }
+    }
+  }
+};
+
+function getOptions() {
+  return apos.modules['@apostrophecms/rich-text-widget'];
+}
+</script>
+
+<style lang="scss" scoped>
+  .apos-ai-helper-text__dialog {
+    z-index: $z-index-modal;
+    position: absolute;
+    top: calc(100% + 5px);
+    left: -15px;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .apos-ai-helper-text__dialog.apos-is-triggered {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .apos-context-menu__dialog {
+    width: 500px;
+  }
+
+  textarea {
+    width: 100%;
+  }
+
+  .apos-is-active {
+    background-color: var(--a-base-7);
+  }
+
+  .apos-ai-helper-text__footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+  }
+
+  .apos-ai-helper-text__footer .apos-button__wrapper {
+    margin-left: 7.5px;
+  }
+
+  .apos-ai-helper-text__remove {
+    display: flex;
+    justify-content: flex-end;
+  }
+</style>

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
@@ -41,7 +41,7 @@
 <script>
 export default {
   name: 'AposAiHelperTextDialog',
-  emits: [ 'close', 'beforeCommands' ],
+  emits: [ 'close', 'before-commands' ],
   props: {
     editor: {
       type: Object,
@@ -87,7 +87,7 @@ export default {
           },
           busy: true
         });
-        this.$emit('beforeCommands');
+        this.$emit('before-commands');
         // newlines shouldn't matter but they do to tiptap, so get rid of them
         const html = result.html.replace(/>\n+</g, '><');
         this.editor.commands.insertContent(html);

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
@@ -71,7 +71,6 @@ export default {
   },
   methods: {
     close() {
-      console.log('emitting close');
       this.$emit('close');
     },
     async save() {
@@ -86,7 +85,9 @@ export default {
           busy: true
         });
         this.$emit('beforeCommands');
-        this.editor.commands.insertContent(result.html);
+        // newlines shouldn't matter but they do to tiptap, so get rid of them
+        const html = result.html.replace(/>\n+</g, '><');
+        this.editor.commands.insertContent(html);
         this.close();
       } catch (e) {
         console.error(e);

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
@@ -13,7 +13,10 @@
       menu-placement="bottom-start"
     >
       <form class="apos-ai-helper-form">
-        <textarea v-model="prompt" :placeholder="$t('aposAiHelper:textPlaceholderText')" />
+        <p>
+          {{ $t('aposAiHelper:textPromptLabel') }}
+        </p>
+        <textarea v-model="prompt" />
         <p v-if="error">
           An error occurred.
         </p>
@@ -126,8 +129,17 @@ function getOptions() {
     width: 500px;
   }
 
+  p {
+    font-size: 14px;
+    line-height: 1.25;
+  }
+
   textarea {
     width: 100%;
+    line-height: 1.25;
+    padding: 4px;
+    height: 48px;
+    resize: none;
   }
 
   .apos-is-active {

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
@@ -47,6 +47,10 @@ export default {
     active: {
       type: Boolean,
       required: true
+    },
+    options: {
+      type: Object,
+      required: true
     }
   },
   data() {
@@ -73,15 +77,16 @@ export default {
     async save() {
       this.error = false;
       try {
+        const headingLevels = this.options.styles.filter(style => style.tag.match(/^h\d$/)).map(style => parseInt(style.tag.replace(/h/i, '')));
         const result = await self.apos.http.post(`${getOptions().action}/ai-helper`, {
           body: {
-            prompt: this.prompt
+            prompt: this.prompt,
+            headingLevels            
           },
           busy: true
         });
-        console.log(JSON.stringify(result, null, '  '));
         this.$emit('beforeCommands');
-        this.editor.commands.insertContent(result.text);
+        this.editor.commands.insertContent(result.html);
         this.close();
       } catch (e) {
         console.error(e);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "cuid": "^3.0.0",
+    "form-data": "^4.0.0",
     "node-fetch": "^2.6.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "cuid": "^3.0.0",
     "form-data": "^4.0.0",
+    "marked": "^4.3.0",
     "node-fetch": "^2.6.9"
   }
 }


### PR DESCRIPTION
Initial implementation. See the `ai-helper` branch of `a3-demo` for a working example, you need the `floating-menu-test` branch of apostrophe with this.

Type a / in rich text to see the insert menu option for AI text generation. For images, start like you normally would, then click the little robot icon at upper right in the media manager in lieu of uploading an image file.