### PR TITLE
PRO-6184: security & necessary housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.0-beta.8 (2024-08-09)
+
+* Security: Apostrophe now checks to make sure the current user can edit at least one type of content on the site before making calls to the OpenAI APIs. Upgrading is recommended.
+* Updated to use the gpt4o text model by default.
+* Image model can be explicitly specified and defaults to `dall-e-2`. Note that `dall-e-3` does not support variations in the same way, so the current UI will have to change if that feature is not added upstream.
+
+
 ## 1.0.0-beta.7 (2024-07-10)
 
 * Add missing UI translation keys.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ modules: {
   '@apostrophecms/ai-helper': {
     // Optional: specify a particular GPT model name.
     // This is the default:
-    textModel: 'gpt-3.5-turbo-instruct',
+    textModel: 'gpt-4o',
+    // Optional: specify a particular Dall-E image
+    // generation model name. This is the default.
+    // Note: dall-e-3 currently lacks features needed
+    // by this module
+    imageModel: 'dall-e-2',
     // Optional: override the maximum number of tokens,
     // up to GPT's limit for the model. This is the default:
     textMaxTokens: 1000

--- a/i18n/aposAiHelper/en.json
+++ b/i18n/aposAiHelper/en.json
@@ -3,7 +3,7 @@
   "generateTextLabel": "Generate Text",
   "generateTextDescription": "Generate text with AI",
   "imagePlaceholderText": "Describe the image you want to create.",
-  "textPromptLabel": "Enter a prompt to generate text. Example: \"100 words about cheese, in the style of Anthony Bourdain, with subheadings\"",
+  "textPromptLabel": "Enter a prompt to generate text. Example: \"100 words about cheese, with subheadings\"",
   "variations": "Variations",
   "select": "Select",
   "delete": "Delete",

--- a/index.js
+++ b/index.js
@@ -18,8 +18,21 @@ module.exports = {
     modules: getBundleModuleNames()
   },
   options: {
-    textModel: 'gpt-3.5-turbo-instruct',
-    textMaxTokens: 1000
+    textModel: 'gpt-4o',
+    textMaxTokens: 1000,
+    // Note: dall-e-3 does not support variations
+    imageModel: 'dall-e-2'
+  },
+  methods(self) {
+    return {
+      checkPermissions(req) {
+        // If the user cannot edit at least one content type, they have
+        // no business talking to the AI
+        if (!Object.keys(self.apos.modules).some(type => self.apos.permission.can(req, 'edit', type))) {
+          throw self.apos.error('forbidden');
+        }
+      }
+    }
   }
 };
 

--- a/modules/@apostrophecms/ai-helper-image/index.js
+++ b/modules/@apostrophecms/ai-helper-image/index.js
@@ -76,6 +76,8 @@ module.exports = {
       },
       post: {
         async 'ai-helper'(req) {
+          const aiHelper = self.apos.modules['@apostrophecms/ai-helper'];
+          aiHelper.checkPermissions(req);
           const prompt = self.apos.launder.string(req.body.prompt);
           const variantOf = self.apos.launder.id(req.body.variantOf);
           if (!prompt.length) {
@@ -87,6 +89,7 @@ module.exports = {
           }
           set('n', 4);
           set('size', '1024x1024');
+          set('model', aiHelper.options.imageModel);
           let temp;
           // Fake results for cheap & offline testing
           if (process.env.APOS_AI_HELPER_MOCK) {

--- a/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
+++ b/modules/@apostrophecms/ai-helper-image/ui/apos/components/AposAiHelperImageManager.vue
@@ -108,7 +108,6 @@ export default {
         this.images = [ ...result.images, ...this.images ];
         this.$el.querySelector('[data-apos-modal-inner]').scrollTo(0, 0);
       } catch (e) {
-        console.error(e);
         this.error = true;
       }
     },

--- a/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
+++ b/modules/@apostrophecms/ai-helper-rich-text-widget/ui/apos/components/AposAiHelperTextDialog.vue
@@ -82,7 +82,7 @@ export default {
     async save() {
       this.error = false;
       try {
-        const headingLevels = this.options.styles.filter(style => style.tag.match(/^h\d$/)).map(style => parseInt(style.tag.replace(/h/i, '')));
+        const headingLevels = (this.options.styles || []).filter(style => style.tag.match(/^h\d$/)).map(style => parseInt(style.tag.replace(/h/i, '')));
         const result = await self.apos.http.post(`${getOptions().action}/ai-helper`, {
           body: {
             prompt: this.prompt,
@@ -96,7 +96,6 @@ export default {
         this.editor.commands.insertContent(html);
         this.done();
       } catch (e) {
-        console.error(e);
         this.error = true;
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apostrophecms/ai-helper",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "AI helpers for content creation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Fixed the security issue: only users who can edit something should be able to cause this content generation helper module to communicate with OpenAI
* Updated to use current APIs
* Updated default text model
* Specify image model, make it configurable (using dall-e-3 would require some  changes though due to missing features in dall-e-3)

NOTE: when you generate and select an image, it is supposed to immediately appear in the media library and be selected, but right now it doesn't. This is due to a separate, known regression in apostrophe itself and a ticket has been opened for refinement. You can still pick that image if you exit the media library and reopen it etc.
